### PR TITLE
I2C communication in library is not working

### DIFF
--- a/src/M5_JoyC.cpp
+++ b/src/M5_JoyC.cpp
@@ -10,8 +10,8 @@ bool M5_JOYC::begin(
 	_addr = addr;
   	_sda = sda;
 	_scl = scl;
-	_wire->begin(_sda, _scl, 100);
-	delay(10);
+	_wire->setPins(_sda, _scl);
+	_wire->begin();
 	_wire->beginTransmission(_addr);
 	uint8_t error = _wire->endTransmission();
     if(error == 0)


### PR DESCRIPTION
Seems there are issues with GPIO0 initialisation, when using the the current ESP32 Arduino library.

```
M5StickC initializing...OK
[   653][W][Wire.cpp:204] begin(): Bus already started in Master Mode.
[  5653][I][esp32-hal-i2c-slave.c:234] i2cSlaveInit(): Initialising I2C Slave: sda=26 scl=100 freq=100000, addr=0x0
E (5651) gpio: gpio_set_level(226): GPIO output gpio_num error
E (5656) gpio: gpio_set_level(226): GPIO output gpio_num error
[  5664][W][esp32-hal-i2c-slave.c:548] i2c_slave_check_line_state(): invalid state sda(26)=1, scl(100)=0
E (5670) gpio: gpio_set_level(226): GPIO output gpio_num error
E (5676) gpio: gpio_set_level(226): GPIO output gpio_num error
E (5681) gpio: gpio_set_level(226): GPIO output[ 10803][E][esp32-hal-i2c.c:142] i2cWrite(): could not acquire lock
[ 10803][E][esp32-hal-i2c.c:196] i2cRead(): could not acquire lock
[ 10804][E][esp32-hal-i2c.c:142] i2cWrite(): could not acquire lock
[ 10810][E][esp32-hal-i2c.c:196] i2cRead(): could not acquire lock
X0: 255 Y0: 255
X1: 255 Y1: 255
```

This change makes it working.
```
M5StickC initializing...OK
[   653][W][Wire.cpp:204] begin(): Bus already started in Master Mode.
X0: 182 Y0: 161
X1: 133 Y1: 196
```